### PR TITLE
feat: Implement monthly fallback for news updates

### DIFF
--- a/update_readme.py
+++ b/update_readme.py
@@ -2,6 +2,9 @@ import os
 import json
 import requests
 from datetime import datetime, timedelta
+# For robust month calculations, dateutil.relativedelta can be useful.
+# Ensure 'python-dateutil' is added to dependencies if you use it.
+# For this implementation, we'll use datetime and timedelta.
 
 # Define the history directory
 NEWS_HISTORY_DIR = "news_history"
@@ -28,25 +31,38 @@ def search_brave(query, count=30):
         print(f"Error during Brave API request: {e}")
         return {"web": {"results": []}}
 
-def generate_readme_content(news_data_from_history_file):
-    current_date_in_header = datetime.now().strftime("%B %d, %Y")
-    
-    api_response_data = news_data_from_history_file.get('api_response', {})
+def generate_readme_content(data_saved_to_history, news_period_label=""): 
+    api_response_data = data_saved_to_history.get('api_response', {})
+    query_details = data_saved_to_history.get('query_details', {})
     results = api_response_data.get('web', {}).get('results', [])
     
     content_parts = []
-    content_parts.append(f"# Quantum Computing News Tracker\n\n")
+    content_parts.append("# Quantum Computing News Tracker\n\n")
     content_parts.append("A curated collection of the latest developments, breakthroughs, and news in the field of Quantum Computing.\n\n")
-    content_parts.append(f"## Latest Updates ({current_date_in_header})\n\n")
+    
+    header_text = news_period_label if news_period_label else datetime.now().strftime("%B %d, %Y")
+    content_parts.append(f"## Latest Updates ({header_text})\n\n")
     
     if not results:
-        content_parts.append("No new relevant articles found for the latest period.\n")
+        search_type = query_details.get("search_type", "weekly")
+        if search_type == "monthly_fallback":
+            content_parts.append("No new relevant articles found for the past week. Displaying notable articles from the past month.\n")
+            # Check again if fallback also yielded nothing specifically for the message
+            if not api_response_data.get('web', {}).get('results', []): # Check results from fallback specifically
+                 content_parts.append("No notable articles found for the past month either.\n")
+        else: # weekly search that found nothing
+            content_parts.append("No new relevant articles found for the past week. Consider checking the archive or if a fallback monthly search occurs next.\n")
+    else: # Results were found
+        search_type = query_details.get("search_type", "weekly")
+        if search_type == "monthly_fallback":
+             content_parts.append("No new relevant articles found for the past week. Displaying notable articles from the past month:\n\n")
+
 
     model_releases = []
     innovations = []
     market_trends = []
     
-    for item in results:
+    for item in results: # Iterate through results from either primary or fallback
         title = item.get('title', 'N/A')
         description = item.get('description', 'No description available.')
         url = item.get('url', '#')
@@ -74,11 +90,9 @@ def generate_readme_content(news_data_from_history_file):
         content_parts.append("\n".join(market_trends[:5]))
     
     if results and (model_releases or innovations or market_trends):
-        content_parts.append("\n") # Add a newline before archive if there was categorized content
+        content_parts.append("\n")
 
-    # Using a raw string literal for the static part of the README
-    # to avoid issues with backslashes if any were present.
-    content_parts.append(r'''
+    full_static_readme_part = r'''
 ## News Archive
 
 Past weekly news updates can be found in the [`news_history`](./news_history/) directory. Files are named with the start date of the week they cover (e.g., `YYYY-MM-DD_quantum_news.json`).
@@ -116,48 +130,90 @@ The information provided in this repository is compiled from various sources and
 ## License
 
 This repository is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-''')
+'''
+    content_parts.append(full_static_readme_part)
     return "".join(content_parts)
 
-def get_date_range_for_query():
+def get_previous_week_date_range():
     today = datetime.now()
-    # Assuming the script runs on Monday (weekday() == 0) as per cron
-    # Last week Sunday is `today - timedelta(days=today.weekday() + 1)`
-    # Last week Monday is `last week Sunday - timedelta(days=6)`
-    end_of_last_week = today - timedelta(days=today.weekday() + 1)
-    start_of_last_week = end_of_last_week - timedelta(days=6)
+    # Monday of the current week
+    start_of_this_week = today - timedelta(days=today.weekday())
+    # Monday of last week
+    start_of_last_week = start_of_this_week - timedelta(days=7)
+    # Sunday of last week
+    end_of_last_week = start_of_last_week + timedelta(days=6)
     return start_of_last_week.strftime("%Y-%m-%d"), end_of_last_week.strftime("%Y-%m-%d")
+
+def get_previous_month_date_range():
+    today = datetime.now()
+    # First day of current month
+    first_day_current_month = today.replace(day=1)
+    # Last day of previous month is one day before first day of current month
+    last_day_previous_month = first_day_current_month - timedelta(days=1)
+    # First day of previous month
+    first_day_previous_month = last_day_previous_month.replace(day=1)
+    return first_day_previous_month.strftime("%Y-%m-%d"), last_day_previous_month.strftime("%Y-%m-%d")
 
 def main():
     print(f"Script started at {datetime.now().isoformat()}")
-    
+    search_type = "weekly" 
+    news_period_label_for_readme = ""
+    actual_start_date_str, actual_end_date_str = "", "" # To store dates of data actually fetched
+
     if not os.path.exists(NEWS_HISTORY_DIR):
         try:
             os.makedirs(NEWS_HISTORY_DIR)
             print(f"Created directory: {NEWS_HISTORY_DIR}")
         except OSError as e:
             print(f"Error creating directory {NEWS_HISTORY_DIR}: {e}")
-            return # Exit if cannot create history directory
+            return
 
-    start_date_str, end_date_str = get_date_range_for_query()
-    # Using a common search engine syntax for date ranges.
-    query = f'"Quantum Computing" AND "AI" AND "news" after:{start_date_str} before:{end_date_str}'
-
-    print(f"Fetching news for period: {start_date_str} to {end_date_str} with query: '{query}'")
-    raw_api_response = search_brave(query) # Default count is 30
+    # Primary search: Previous Week
+    intended_start_week, intended_end_week = get_previous_week_date_range()
+    actual_start_date_str, actual_end_date_str = intended_start_week, intended_end_week
     
+    query = f'"Quantum Computing" AND "AI" AND "news" after:{actual_start_date_str} before:{actual_end_date_str}'
+    print(f"Attempting primary search (previous week): {actual_start_date_str} to {actual_end_date_str}")
+    raw_api_response = search_brave(query)
+    
+    news_period_label_for_readme = f"Week of {datetime.strptime(actual_start_date_str, '%Y-%m-%d').strftime('%B %d, %Y')}"
+
+    # Fallback search: Previous Month (if no results from weekly)
+    # Define "no results" as an empty list for 'results' key in 'web'
+    results_found = raw_api_response.get('web', {}).get('results', [])
+    if not results_found:
+        print("No results found for the previous week. Attempting fallback to previous month.")
+        search_type = "monthly_fallback"
+        
+        actual_start_date_str, actual_end_date_str = get_previous_month_date_range()
+        query = f'"Quantum Computing" AND "AI" AND "news" after:{actual_start_date_str} before:{actual_end_date_str}'
+        print(f"Attempting fallback search (previous month): {actual_start_date_str} to {actual_end_date_str}")
+        raw_api_response = search_brave(query) # This will be the response used if fallback happens
+        # Update label for README to reflect monthly fallback
+        month_dt = datetime.strptime(actual_start_date_str, '%Y-%m-%d')
+        news_period_label_for_readme = f"Month of {month_dt.strftime('%B %Y')}"
+        # Re-check if fallback also has results for accurate messaging in generate_readme_content
+        results_found = raw_api_response.get('web', {}).get('results', [])
+
+
+    # Prepare data for saving
+    # History filename is based on the script's run week, not the data's period (if fallback)
+    history_file_run_date_prefix = intended_start_week 
+
     data_to_save = {
         "query_details": {
-            "query_sent": query,
-            "period_start_date": start_date_str,
-            "period_end_date": end_date_str,
+            "query_sent": query, 
+            "intended_period_start_date": intended_start_week,
+            "intended_period_end_date": intended_end_week,
+            "actual_data_period_start": actual_start_date_str, # Start date of the data in api_response
+            "actual_data_period_end": actual_end_date_str,     # End date of the data in api_response
+            "search_type": search_type,
             "retrieval_timestamp": datetime.now().isoformat()
         },
         "api_response": raw_api_response 
     }
 
-    history_file_date_prefix = start_date_str 
-    history_filename = os.path.join(NEWS_HISTORY_DIR, f"{history_file_date_prefix}_quantum_news.json")
+    history_filename = os.path.join(NEWS_HISTORY_DIR, f"{history_file_run_date_prefix}_quantum_news.json")
     
     try:
         with open(history_filename, 'w', encoding='utf-8') as f:
@@ -165,10 +221,8 @@ def main():
         print(f"News data saved to {history_filename}")
     except IOError as e:
         print(f"Error saving news data to {history_filename}: {e}")
-        # Continue and update README with current data even if saving history fails,
-        # but log the error. The problem would be that history is not persisted.
 
-    new_readme_content = generate_readme_content(data_to_save) 
+    new_readme_content = generate_readme_content(data_to_save, news_period_label_for_readme) 
     
     try:
         with open('README.md', 'w', encoding='utf-8') as f:


### PR DESCRIPTION
This commit enhances the news update script (`update_readme.py`) to include a fallback mechanism:

- If the primary search for the previous week's news yields no results, the script now performs a secondary search for notable news from the entire previous month.
- The `news_history` JSON files have been updated to store:
    - `search_type`: Indicates if the data is from a "weekly" or "monthly_fallback" search.
    - `intended_period_start_date` & `intended_period_end_date`: The original weekly period the script targeted.
    - `actual_data_period_start` & `actual_data_period_end`: The date range of the news actually fetched (weekly or monthly).
- The `README.md` generation logic was updated to:
    - Display a dynamic header in "Latest Updates" reflecting whether the news is from the past week or past month.
    - Provide more specific messages if no news is found, accounting for the fallback attempt.

This change makes the news tracker more resilient by ensuring that if no immediate weekly news is found, you are still presented with more relevant recent (monthly) articles instead of an empty update.